### PR TITLE
feat: Update E2E tests per issue #30

### DIFF
--- a/src/commands/e2e.ts
+++ b/src/commands/e2e.ts
@@ -114,13 +114,6 @@ const KB_TEST_SCENARIOS: Record<string, KBTestScenario[]> = {
   ],
   youtube: [
     {
-      name: 'no_cc',
-      url: 'https://youtu.be/ZpvMhHldAEo',
-      expectedOutcome: 'unprocessable',
-      expectedError: 'transcript-unavailable',
-      description: 'YouTube video without closed captions (should fail)'
-    },
-    {
       name: 'with_cc',
       url: 'https://youtu.be/P9UPOym_tLQ',
       expectedOutcome: 'success',
@@ -523,10 +516,12 @@ async function runKBTypeTest(
     
     } // End of monitorTrainingProgress function
 
-    // Skip chat verification if requested or if expected to fail
-    if (skipChatVerification || scenario.expectedOutcome === 'unprocessable') {
+    // Skip chat verification if requested, if expected to fail, or for website scenarios
+    if (skipChatVerification || scenario.expectedOutcome === 'unprocessable' || kbType === 'website') {
       if (skipChatVerification) {
         console.log(chalk.gray(`  [${kbType}/${scenario.name}] [KB:${kbId}] Skipping chat verification as requested`));
+      } else if (kbType === 'website') {
+        console.log(chalk.gray(`  [${kbType}/${scenario.name}] [KB:${kbId}] Skipping chat verification for website scenario`));
       } else {
         console.log(chalk.gray(`  [${kbType}/${scenario.name}] [KB:${kbId}] Skipping chat verification for expected failure scenario`));
       }
@@ -552,9 +547,6 @@ async function runKBTypeTest(
       case 'text':
       case 'file':
         testMessage = `What is the secret phrase you were trained on?`;
-        break;
-      case 'website':
-        testMessage = `What content did you learn from the website I provided?`;
         break;
       case 'youtube':
         if (scenario.name === 'with_cc') {
@@ -599,7 +591,7 @@ async function runKBTypeTest(
         console.log(chalk.gray(`  [${kbType}/${scenario.name}] [KB:${kbId}] Response: ${responseContent.substring(0, 100)}...`));
       }
     } else {
-      // For website and youtube (non-cc), just check if there's a reasonable response
+      // For youtube (non-cc), just check if there's a reasonable response
       // since we can't predict exact content
       verificationPassed = responseContent.length > 20 && 
                          !responseContent.toLowerCase().includes('i don\'t have') &&


### PR DESCRIPTION
## Summary
- Removed completion verification for website scenarios
- Removed non-cc scenario from YouTube tests as requested

## Changes Made
1. **Website scenarios**: Now skip chat verification entirely (similar to how unprocessable scenarios are handled)
2. **YouTube tests**: Removed the non-cc scenario, keeping only the with_cc scenario
3. **Code cleanup**: Removed unreachable website case from switch statement and updated comments

## Implementation Details
- Added `kbType === 'website'` condition to skip chat verification
- Removed the entire non-cc scenario object from the YouTube test scenarios array
- Updated console log messages to properly indicate when skipping website verification
- Cleaned up the switch statement and comments to reflect that website scenarios no longer use chat verification

## Test plan
- [ ] Run E2E tests: `npm run dev -- e2e --kb-types text,file,website,youtube`
- [ ] Verify text and file scenarios still check for completion phrases
- [ ] Verify website scenarios complete without chat verification
- [ ] Verify only with_cc YouTube scenario runs (no non-cc scenario)

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)